### PR TITLE
기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { validateLocaleAndSetLanguage } from "typescript";
 import "./App.css";
 
 declare global {
@@ -10,6 +11,10 @@ declare global {
 
 function App() {
   const mapRef = useRef<HTMLDivElement>(null);
+  const [markerList, setMarkerList] = useState<any[]>([]);
+  //const map = useState<any>(null);
+  const map = useRef<any>(null);
+
   useEffect(() => {
     //#1 index.html에 script를 작성(api키와 세부내용 모두 작성)하고 불러오기
     //window.loadMap()
@@ -43,17 +48,29 @@ function App() {
     document.head.appendChild(script);
 
     script.onload = () => {
-      console.log("hello");
       window.kakao.maps.load(() => {
         if (mapRef.current) {
           var options = {
             center: new window.kakao.maps.LatLng(33.450701, 126.570667),
-            level: 3,
+            level: 10,
           };
 
-          var map = new window.kakao.maps.Map(mapRef.current, options);
-
-          console.log(mapRef.current);
+          map.current = new window.kakao.maps.Map(mapRef.current, options);
+          //setMaps(new window.kakao.maps.Map(mapRef.current,options));
+          window.kakao.maps.event.addListener(
+            map.current,
+            "rightclick",
+            (mouseEvent: any) => {
+              const latlng = mouseEvent.latLng;
+              const title = prompt("마커의 타이틀 입력");
+              var marker = new window.kakao.maps.Marker({
+                map: map.current,
+                position: latlng,
+                title,
+              });
+              setMarkerList((prev) => [...prev, marker]);
+            }
+          );
         }
       });
     };
@@ -62,14 +79,61 @@ function App() {
   }, []);
 
   return (
-    <div
-      ref={mapRef}
-      style={{
-        width: 300,
-        height: 300,
-      }}
-    >
-      뭐요
+    <div>
+      <button
+        onClick={() => {
+          map.current.setCenter(
+            new window.kakao.maps.LatLng(37.5666805, 126.9784147)
+          );
+          map.current.setLevel(10);
+        }}
+      >
+        서울
+      </button>
+      <button
+        onClick={() => {
+          map.current.setCenter(
+            new window.kakao.maps.LatLng(35.1379222, 129.05562775)
+          );
+          map.current.setLevel(5);
+        }}
+      >
+        부산
+      </button>
+      <input
+        type="range"
+        min="1"
+        max="20"
+        onChange={(ev) => {
+          map.current.setLevel(ev.currentTarget.value, { animate: true });
+        }}
+      />
+      <button
+        onClick={() => {
+          map.current.getMapTypeId() === 3
+            ? map.current.setMapTypeId(window.kakao.maps.MapTypeId.ROADMAP)
+            : map.current.setMapTypeId(window.kakao.maps.MapTypeId.HYBRID);
+        }}
+      >
+        지도 타입 변경
+      </button>
+      <div
+        ref={mapRef}
+        style={{
+          width: 300,
+          height: 300,
+        }}
+      ></div>
+      {markerList.map((value) => (
+        <div
+          onClick={() => {
+            value.setMap(null);
+            setMarkerList(markerList.filter((v) => v !== value));
+          }}
+        >
+          {value.getTitle()}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
* `서울` `부산` 버튼을 추가함. 클릭하면 해당 위도와 경도로 이동하여 지도에서 표시한다.

* `range`형태의 `input`을 추가해서 조절하는 만큼 지도의 확대와 축소된다. (최소 1, 최대 20)

* 지도 타입 변경 버튼을 추가해서 클릭하면 지도의 유형이 변경된다.(`HYBRID`로 변경) 만약에 클릭했을때 지도의 `TypeId()`의 값이 3(`HYBRID의 ID값`)일 경우 원래 상태로 돌아오고, 그 반대의 경우에는 지도의 유형이 변경된다.


* 마커를 추가해서 지도에서 아무곳이나 마우스 우클릭을 하면, 마커 생성을 위한 이름을 작성하기 위해 `prompt`창이 나타나고 이름을 작성하면 마커 생성 및, 마커의 이름이 지도 하단에 나타난다.

* 마커의 이름을 클릭하면, 마커와 함께 제거된다.